### PR TITLE
Add support for cockpit status (totalMileage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ In these examples, the `MQTT_BASE_TOPIC` is set to the default (`leaf`).
 | ----- | ------- | ----------- |
 | leaf/{vin}/command/location | update | Request an update for the last known location |
 
+### Cockpit Status
+#### Status
+| Topic  | Type | Description |
+| ------ | ---- | ----------- |
+| leaf/{vin}/cockpitStatus/totalMileage | Double | The total mileage from the vehicle. The unit (km or miles) depends on the regional area. |
+
+#### Commands
+| Topic | Payload | Description |
+| ----- | ------- | ----------- |
+| leaf/{vin}/command/cockpitStatus | update | Request an update for the cockpit status |
+
 :information_source: The status and commands for the first Leaf in the account are also supported by using the same topic without the {vin}.
 
 :warning: Not all status and commands are supported for a given leaf type due to Carwings, NissanConnectNA or NissanConnect api limitations.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,8 +57,8 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "4c3aaf35aa82cee808c470b34aa13bd2bca96fd5"
-      url: "https://github.com/Tobiaswk/dartnissanconnect"
+      resolved-ref: e6ef1b1004482f59ea0d08f7bee8cdf1e2fc3cd5
+      url: "https://gitlab.com/sensor-freak/dartnissanconnect"
     source: git
     version: "1.0.0"
   dartnissanconnectna:
@@ -118,7 +118,7 @@ packages:
       name: mqtt_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.6.5"
+    version: "9.6.6"
   path:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   crypto:
     dependency: transitive
     description:
@@ -104,28 +104,28 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.7.0"
   mqtt_client:
     dependency: "direct main"
     description:
       name: mqtt_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.6.1"
+    version: "9.6.5"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: leaf2mqtt
-version: 0.0.1
+version: 0.0.2
 publish_to: 'none'
 dependencies:
   dartnissanconnectna:
     git: https://gitlab.com/tobiaswkjeldsen/dartnissanconnectna
   dartnissanconnect:
-    git: https://github.com/Tobiaswk/dartnissanconnect
+    git: https://gitlab.com/sensor-freak/dartnissanconnect
   dartcarwings:
     git: https://github.com/Tobiaswk/dartcarwings
   mqtt_client: ^9.6.1

--- a/src/leaf/builder/leaf_cockpitstatus_builder.dart
+++ b/src/leaf/builder/leaf_cockpitstatus_builder.dart
@@ -1,0 +1,15 @@
+import 'leaf_builder_base.dart';
+
+class CockpitStatusInfoBuilder extends BuilderBase {
+  CockpitStatusInfoBuilder() : super();
+  CockpitStatusInfoBuilder._withInfo(Map<String, String> info) : super.withInfo(info);
+
+  @override
+  String get baseTopic => 'cockpit';
+
+  CockpitStatusInfoBuilder withTotalMileage(dynamic latitude) =>
+    _withInfo('totalMileage', latitude);
+
+  CockpitStatusInfoBuilder _withInfo(String infoName, dynamic value) =>
+      CockpitStatusInfoBuilder._withInfo(addInfo(infoName, value));
+}

--- a/src/leaf/carwings_wrapper.dart
+++ b/src/leaf/carwings_wrapper.dart
@@ -113,4 +113,10 @@ class CarwingsVehicleWrapper extends VehicleInternal {
       .withLongitude(location.longitude)
       .build());
   }
+
+  // Note: This is only a dummy method. It returns an empty map.
+  @override
+  Future<Map<String, String>> fetchCockpitStatus() async {
+    return Future<Map<String, String>>.value(<String, String>{});
+  }
 }

--- a/src/leaf/leaf_vehicle.dart
+++ b/src/leaf/leaf_vehicle.dart
@@ -73,6 +73,7 @@ abstract class Vehicle {
   Future<bool> stopClimate();
 
   Future<Map<String, String>> fetchLocation();
+  Future<Map<String, String>> fetchCockpitStatus();
 }
 
 

--- a/src/leaf/nissan_connect_na_wrapper.dart
+++ b/src/leaf/nissan_connect_na_wrapper.dart
@@ -113,4 +113,10 @@ class NissanConnectNAVehicleWrapper extends VehicleInternal {
       .withLongitude(location.longitude)
       .build());
   }
+
+  // Note: This is only a dummy method. It returns an empty map.
+  @override
+  Future<Map<String, String>> fetchCockpitStatus() async {
+    return Future<Map<String, String>>.value(<String, String>{});
+  }
 }

--- a/src/leaf/nissan_connect_wrapper.dart
+++ b/src/leaf/nissan_connect_wrapper.dart
@@ -4,6 +4,7 @@ import 'package:dartnissanconnect/src/nissanconnect_hvac.dart';
 import 'builder/leaf_battery_builder.dart';
 import 'builder/leaf_climate_builder.dart';
 import 'builder/leaf_location_builder.dart';
+import 'builder/leaf_cockpitstatus_builder.dart';
 import 'builder/leaf_stats_builder.dart';
 import 'leaf_session.dart';
 import 'leaf_vehicle.dart';
@@ -119,6 +120,14 @@ class NissanConnectVehicleWrapper extends VehicleInternal {
     return saveAndPrependVin(LocationInfoBuilder()
       .withLatitude(location.latitude)
       .withLongitude(location.longitude)
+      .build());
+  }
+
+  @override
+  Future<Map<String, String>> fetchCockpitStatus() async {
+    final NissanConnectCockpitStatus cockpitStatus = await _getVehicle().requestCockpitStatus();
+    return saveAndPrependVin(CockpitStatusInfoBuilder()
+      .withTotalMileage(cockpitStatus.totalMileage)
       .build());
   }
 }

--- a/src/leaf_2_mqtt.dart
+++ b/src/leaf_2_mqtt.dart
@@ -36,7 +36,7 @@ Future<void> main() async {
   final String leafPassword = envVars['LEAF_PASSWORD'];
 
   if ((leafUser?.isEmpty ?? true) || (leafPassword?.isEmpty ?? true)) {
-    _log.severe('LEAF_USER and LEAF_PASSWORD environment variables must be set.');
+    _log.severe('LEAF_USERNAME and LEAF_PASSWORD environment variables must be set.');
     exit(1);
   }
 

--- a/src/leaf_2_mqtt.dart
+++ b/src/leaf_2_mqtt.dart
@@ -252,6 +252,12 @@ Future<void> fetchAndPublishLocation(MqttClientWrapper mqttClient, String vin) {
            vehicle.fetchLocation(), vin).then(mqttClient.publishStates);
 }
 
+Future<void> fetchAndPublishCockpitStatus(MqttClientWrapper mqttClient, String vin) {
+  _log.finer('fetchAndPublishCockpit for $vin');
+  return _session.executeWithRetry((Vehicle vehicle) =>
+           vehicle.fetchCockpitStatus(), vin).then(mqttClient.publishStates);
+}
+
 Future<void> fetchAndPublishAllStatus(MqttClientWrapper mqttClient, String vin) {
   _log.finer('fetchAndPublishAllStatus for $vin');
   return Future.wait(<Future<void>> [
@@ -259,7 +265,8 @@ Future<void> fetchAndPublishAllStatus(MqttClientWrapper mqttClient, String vin) 
       _session.executeSync((Vehicle vehicle) => vehicle.getVehicleStatus(), vin))),
     fetchAndPublishBatteryStatus(mqttClient, vin),
     fetchAndPublishClimateStatus(mqttClient, vin),
-    fetchAndPublishLocation(mqttClient, vin)
+    fetchAndPublishLocation(mqttClient, vin),
+    fetchAndPublishCockpitStatus(mqttClient, vin)
   ]);
 }
 

--- a/src/leaf_2_mqtt.dart
+++ b/src/leaf_2_mqtt.dart
@@ -220,6 +220,15 @@ void subscribeToCommands(MqttClientWrapper mqttClient, String vin) {
         default:
       }
     });
+
+  subscribe('command/cockpitStatus', (String payload) {
+    switch (payload) {
+      case 'update':
+          fetchAndPublishCockpitStatus(mqttClient, vin);
+        break;
+      default:
+    }
+  });
 }
 
 Future<void> fetchAndPublishDailyStats(MqttClientWrapper mqttClient, String vin, DateTime targetDay) {


### PR DESCRIPTION
These changes are based on a fork of the `dartnissanconnect` library, which adds support for the cockpit status, which contains the `totalMileage` value.