### PR TITLE
Correct add on to use `options` instead of `config.

### DIFF
--- a/addon/config.json
+++ b/addon/config.json
@@ -10,11 +10,11 @@
     "aarch64",
     "amd64"
   ],
-  "config": {
+  "options": {
     "LEAF_USERNAME": "",
     "LEAF_PASSWORD": "",
     "LEAF_TYPE": "",
-    "MQTT_HOST": "",
+    "MQTT_HOST": "homeassistant.local",
     "MQTT_PORT": "",
     "MQTT_USERNAME": "",
     "MQTT_PASSWORD": "",


### PR DESCRIPTION
Corrected the object name `config` to `options` and added a suggested default value for MQTT host. 

After discussion with Frenck on Discord, I've found that the object `config` doesn't exist, it should be `options`.  This wasn't obvious because we weren't actually providing any default values anyway.
I've also stuck in a default MQTT host of `homeassistant.local` for good measure, but obviously it's just a suggested value.  Do feel free to drop it if you prefer.

https://developers.home-assistant.io/docs/add-ons/configuration/#options--schema

I mostly only spotted this as I'm using your work as inspiration on another project and noticed I couldn't find any mention of the `config` object in the docs so asked on the HA discord about it and was assured it has never existed.